### PR TITLE
Mobile Auto-Zoom Fix

### DIFF
--- a/src/scss/botchat.scss
+++ b/src/scss/botchat.scss
@@ -868,7 +868,9 @@
             /* making input font size 16 rather than 15 should prevent 
             safari iOS from auto zooming onto text field,
             and thus should solve other sizing issues.  */
-            font-size: 16px;
+            @include mobileAndTablet {
+              font-size: 16px;
+            }
         }
         
         

--- a/src/scss/botchat.scss
+++ b/src/scss/botchat.scss
@@ -865,8 +865,13 @@
             padding-top:11.5px;
             padding-bottom: 12px;
             letter-spacing: 0.4px;
+            /* making input font size 16 rather than 15 should prevent 
+            safari iOS from auto zooming onto text field,
+            and thus should solve other sizing issues.  */
+            font-size: 16px;
         }
-
+        
+        
         ::-webkit-input-placeholder {color: #979999; opacity: 1;}
         :-moz-placeholder           {color: #979999; opacity: 1;}
         ::-moz-placeholder          {color: #979999; opacity: 1;}


### PR DESCRIPTION
This small font-size shift should solve a Safari mobile issue, where the browser would auto zoom onto our bot upon a user selecting the field to type.

## This Pull Request contains the following:
* [ ] An updated CHANGELOG.md describing my changes under the [Unreleased] section in 80 characters or less.
* [ ] Tests that:
   * Test for regressions on bugs that our tests did not catch.
   * Are needed to harden new features.
