### PR TITLE
Additional feedback and bot name

### DIFF
--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -326,7 +326,7 @@ export class Chat extends React.Component<ChatProps, State> {
                         }
 
                         if (bot_display_options && (bot_display_options.bottomOffset || bot_display_options.topOffset || bot_display_options.rightOffset || bot_display_options.fullHeight)) {
-                            const { bottomOffset, topOffset, rightOffset, fullHeight } = bot_display_options;
+                            const { bottomOffset, topOffset, rightOffset, fullHeight, display_name } = bot_display_options;
 
                             this.store.dispatch({
                                 type: 'Set_Format_Options',
@@ -334,7 +334,8 @@ export class Chat extends React.Component<ChatProps, State> {
                                     bottomOffset,
                                     topOffset,
                                     rightOffset,
-                                    fullHeight
+                                    fullHeight,
+                                    display_name
                                 }
                             });
                         }
@@ -455,6 +456,20 @@ export class Chat extends React.Component<ChatProps, State> {
         }
     }
 
+    private calculateChatviewPanelStyle = (format: FormatOptions) => {
+        const fullHeight = format && format.fullHeight;
+        const bottomOffset = fullHeight ? 0 : (format && format.bottomOffset ? format.bottomOffset + 99 : 17);
+        const topOffset = format && format.topOffset ? format.topOffset : 0;
+        const rightOffset = fullHeight ? 0 : (format && format.rightOffset ? format.rightOffset : -1);
+        const height = fullHeight ? '100vh' : `calc(100vh - ${bottomOffset}px - ${topOffset}px - 20px)`;
+
+        return {
+            bottom: bottomOffset,
+            height,
+            ...(rightOffset !== -1 || (format && format.fullHeight)) && {right: rightOffset}
+        };
+    }
+
     // At startup we do three render passes:
     // 1. To determine the dimensions of the chat panel (nothing needs to actually render here, so we don't)
     // 2. To determine the margins of any given carousel (we just render one mock activity so that we can measure it)
@@ -464,11 +479,7 @@ export class Chat extends React.Component<ChatProps, State> {
         const state = this.store.getState();
         const { open, opened, display } = this.state;
 
-        const bottomOffset = state.format && state.format.bottomOffset ? state.format.bottomOffset + 99 : 109;
-        const topOffset = state.format && state.format.topOffset ? state.format.topOffset : 0;
-        const rightOffset = state.format && state.format.rightOffset ? state.format.rightOffset : 0;
-        const height = `calc(100vh - ${bottomOffset}px - ${topOffset}px - 20px)`;
-        const chatviewPanelStyle = (state.format && state.format.fullHeight) ? { bottom: 0, height: '100vh', borderRadius: 0, right: rightOffset } : { bottom: bottomOffset, height, right: rightOffset };
+        const chatviewPanelStyle = this.calculateChatviewPanelStyle(state.format);
 
         // only render real stuff after we know our dimensions
         return (

--- a/src/FloatingIcon.tsx
+++ b/src/FloatingIcon.tsx
@@ -48,11 +48,16 @@ class FloatingIconView extends React.Component<FloatingIconProps> {
     render() {
         const { visible, activity, logoColor, bottomOffset, rightOffset } = this.props;
 
+        const floatingIconStyle = {
+          ...(bottomOffset > 0) && { bottom: bottomOffset },
+          ...(rightOffset > 0) && { right: rightOffset}
+        };
+
         return (
             <div
                 className="wc-floating-wrap"
                 onClick={() => this.props.clicked() }
-                style={{bottom: bottomOffset, right: rightOffset }}
+                style={floatingIconStyle}
             >
                 {activity && activity.text !== '' && (
                     <span className={`wc-floating-message ${visible && activity != null ? 'visible' : '' }`}>

--- a/src/History.tsx
+++ b/src/History.tsx
@@ -104,6 +104,7 @@ export class HistoryView extends React.Component<HistoryProps, {}> {
             lastMessage={false}
             format={ null }
             fromMe={ false }
+            displayName={ false }
             onClickActivity={ null }
             onClickRetry={ null }
             selected={ false }
@@ -145,9 +146,10 @@ export class HistoryView extends React.Component<HistoryProps, {}> {
                             nextActivityFromMe={ index + 1 < activities.length ? this.props.isFromMe(activities[index + 1]) : false}
                             doCardAction={this.doCardAction}
                             lastMessage={index === activities.length - 1}
-                            showTimestamp={ index === this.props.activities.length - 1 || (index + 1 < this.props.activities.length && suitableInterval(activity, this.props.activities[index + 1])) }
+                            showTimestamp={ index === activities.length - 1 || (index + 1 < activities.length && suitableInterval(activity, activities[index + 1])) }
                             selected={ this.props.isSelected(activity) }
                             fromMe={ this.props.isFromMe(activity) }
+                            displayName={ index === 0 || (!this.props.isFromMe(activity) && this.props.isFromMe(activities[index - 1]))}
                             onClickActivity={ this.props.onClickActivity(activity) }
                             onClickRetry={e => {
                                 // Since this is a click on an anchor, we need to stop it
@@ -273,6 +275,7 @@ const findInitial = (title: string): string => {
 export interface WrappedActivityProps {
     activity: Activity;
     nextActivityFromMe: boolean;
+    displayName: boolean;
     showTimestamp: boolean;
     selected: boolean;
     fromMe: boolean;
@@ -382,11 +385,13 @@ export class WrappedActivity extends React.Component<WrappedActivityProps, {}> {
         );
 
         const avatarColor = this.props.format && this.props.format.themeColor ? this.props.format.themeColor : '#c3ccd0';
-        const avatarInitial = this.props.format && this.props.format.chatTitle && typeof(this.props.format.chatTitle) === 'string' ? findInitial(this.props.format.chatTitle) : 'G';
+        const avatarInitial = this.props.format && this.props.format.display_name && typeof(this.props.format.display_name) === 'string' ? findInitial(this.props.format.display_name) : 'B';
         const showAvatar = this.props.fromMe === false && (this.props.nextActivityFromMe || this.props.lastMessage);
+        const showName = this.props.fromMe === false;
         return (
             <div className={`wc-message-pane from-${who}`}
               >
+                {(this.props.displayName && <span className="wc-message-bot-name">{this.props.format && this.props.format.display_name ? this.props.format.display_name : 'Bot'}</span>)}
                 <div data-activity-id={ this.props.activity.id } className={ wrapperClassName } onClick={ this.props.onClickActivity }>
                     {(showAvatar ?
                       <div className="wc-message-avatar" style={{ background: avatarColor }}>{avatarInitial}</div>

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -212,6 +212,7 @@ export interface FormatState {
     topOffset: number;
     rightOffset: number;
     fullHeight: boolean;
+    display_name: boolean | string;
 }
 
 export type FormatAction = {
@@ -249,7 +250,8 @@ export const format: Reducer<FormatState> = (
         bottomOffset: undefined,
         topOffset: undefined,
         rightOffset: undefined,
-        fullHeight: false
+        fullHeight: false,
+        display_name: undefined
     },
     action: FormatAction
 ) => {

--- a/src/scss/botchat.scss
+++ b/src/scss/botchat.scss
@@ -285,7 +285,7 @@
 
 /* views */
 
-    $rightWeight:20px;
+    $rightWeight:3px;
     $floatingBottom:34px;
     $floatingHeight:55px;
     $bottom:$floatingBottom + $floatingHeight + 20px;
@@ -405,6 +405,19 @@
       display:flex;
       flex-direction: row;
     }
+
+    .wc-message-bot-name {
+      color: $c05;
+      float: left;
+      margin-left: 33px;
+      margin-bottom: 4px;
+      font-weight: normal;
+      font-style: normal;
+      font-stretch: normal;
+      line-height: normal;
+      letter-spacing: 0.03em;
+      font-size: 12px;
+    }
     
     .wc-message-avatar{
         width: 25px;
@@ -415,7 +428,6 @@
         align-items: center;
         justify-content: center;
         color: #f6f7f8;
-        opacity: 75%;
         margin-top:auto;
         margin-bottom: 10px;
     }


### PR DESCRIPTION
Fixed right alignment being overwritten for default state.
Changed default bottom and right to be 17px. Adjusted floating icon to match
Changed avatar opacity 75% -> 100%
Added display name. Fixed issue with new styling for fullHeight and the different offsets
Bot's display_name is now used for avatar and the name is displayed above the first message in any group of messages from the bot