### PR TITLE
Find next 5 available days within 90 day window

### DIFF
--- a/src/api/bot.ts
+++ b/src/api/bot.ts
@@ -53,10 +53,9 @@ export const availableTimes = (
     baseUrl: string,
     directLine: string,
     conversationId: string,
-    startDate: string,
-    endDate: string
+    startDate: string
 ): any => {
-    return axios.get(`${baseUrl}/api/v1/availabilities/available_times?directLine=${directLine}&conversation_id=${conversationId}&start_date=${startDate}&end_date=${endDate}`);
+    return axios.get(`${baseUrl}/api/v1/availabilities/available_times?directLine=${directLine}&conversation_id=${conversationId}&start_date=${startDate}`);
 };
 
 export const mapMessagesToActivities = (messages: any, userId: any): Activity[] => {


### PR DESCRIPTION
Added logic to correctly navigate next/previous with new backend logic for calculating next 3 available days
Sorting keys since the default sort was incorrect in some cases